### PR TITLE
add vjsIconClass for specifying custom icon class

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -66,8 +66,9 @@ class HlsQualitySelectorPlugin {
 
     concreteButtonInstance.addClass('vjs-quality-selector');
     if (!this.config.displayCurrentQuality) {
+      const icon = ` ${this.config.vjsIconClass || 'vjs-icon-hd'}`;
       concreteButtonInstance
-        .menuButton_.$('.vjs-icon-placeholder').className += ' vjs-icon-hd';
+        .menuButton_.$('.vjs-icon-placeholder').className += icon;
     } else {
       this.setButtonInnerText('auto');
     }


### PR DESCRIPTION
Adds support in configuration for `vjsIconClass` that allows specifying custom class(es) for the icon.
Built in icons can be seen here: https://videojs.github.io/font/