### PR TITLE
Default button name

### DIFF
--- a/src/ConcreteButton.js
+++ b/src/ConcreteButton.js
@@ -30,7 +30,10 @@ export default class ConcreteButton extends VideoJsButtonClass {
      * @param {Player} player - videojs player instance
      */
   constructor(player) {
-    super(player, {title: player.localize('Quality')});
+    super(player, {
+      title: player.localize('Quality'),
+      name: "QualityButton"
+    });
   }
 
     /**

--- a/src/ConcreteButton.js
+++ b/src/ConcreteButton.js
@@ -32,7 +32,7 @@ export default class ConcreteButton extends VideoJsButtonClass {
   constructor(player) {
     super(player, {
       title: player.localize('Quality'),
-      name: "QualityButton"
+      name: 'QualityButton'
     });
   }
 


### PR DESCRIPTION
This PR adds a default name to the quality selector component to keep it consistent with naming patterns on other VideoJS components - otherwise it shows up as `null`.