### PR TITLE
Added handling of unknown resolutions

### DIFF
--- a/src/ConcreteButton.js
+++ b/src/ConcreteButton.js
@@ -31,7 +31,7 @@ export default class ConcreteButton extends VideoJsButtonClass {
      */
   constructor(player) {
     super(player, {
-      title: player.localize('Jakość'),
+      title: player.localize('Quality'),
       name: 'QualityButton'
     });
   }

--- a/src/ConcreteButton.js
+++ b/src/ConcreteButton.js
@@ -31,7 +31,7 @@ export default class ConcreteButton extends VideoJsButtonClass {
      */
   constructor(player) {
     super(player, {
-      title: player.localize('Quality'),
+      title: player.localize('Jakość'),
       name: 'QualityButton'
     });
   }

--- a/src/ConcreteMenuItem.js
+++ b/src/ConcreteMenuItem.js
@@ -8,14 +8,14 @@ const VideoJsMenuItemClass = videojs.getComponent('MenuItem');
  */
 export default class ConcreteMenuItem extends VideoJsMenuItemClass {
 
-    /**
-     * Menu item constructor.
-     *
-     * @param {Player} player - vjs player
-     * @param {Object} item - Item object
-     * @param {ConcreteButton} qualityButton - The containing button.
-     * @param {HlsQualitySelectorPlugin} plugin - This plugin instance.
-     */
+  /**
+   * Menu item constructor.
+   *
+   * @param {Player} player - vjs player
+   * @param {Object} item - Item object
+   * @param {ConcreteButton} qualityButton - The containing button.
+   * @param {HlsQualitySelectorPlugin} plugin - This plugin instance.
+   */
   constructor(player, item, qualityButton, plugin) {
     super(player, {
       label: item.label,
@@ -27,17 +27,17 @@ export default class ConcreteMenuItem extends VideoJsMenuItemClass {
     this.plugin = plugin;
   }
 
-    /**
-     * Click event for menu item.
-     */
+  /**
+   * Click event for menu item.
+   */
   handleClick() {
 
-        // Reset other menu items selected status.
+    // Reset other menu items selected status.
     for (let i = 0; i < this.qualityButton.items.length; ++i) {
       this.qualityButton.items[i].selected(false);
     }
 
-        // Set this menu item to selected, and set quality.
+    // Set this menu item to selected, and set quality.
     this.plugin.setQuality(this.item.value);
     this.selected(true);
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -115,11 +115,12 @@ class HlsQualitySelectorPlugin {
       }).length) {
         const itemHeight = levels[i].height;
         let label = itemHeight + 'p';
+
         if (itemHeight === undefined) {
           label = 'source';
         }
         const levelItem = this.getQualityMenuItem.call(this, {
-          label: label,
+          label,
           value: itemHeight
         });
 
@@ -147,7 +148,7 @@ class HlsQualitySelectorPlugin {
     }));
 
     if (this._qualityButton) {
-      this._qualityButton.createItems = function () {
+      this._qualityButton.createItems = function() {
         return levelItems;
       };
       this._qualityButton.update();
@@ -167,7 +168,8 @@ class HlsQualitySelectorPlugin {
     this._currentQuality = height;
 
     if (this.config.displayCurrentQuality) {
-      let label = `${height}p`
+      let label = `${height}p`;
+
       if (height === undefined) {
         label = 'source';
       }
@@ -224,7 +226,7 @@ const onPlayerReady = (player, options) => {
  * @param    {Object} [options={}]
  *           An object of options left to the plugin author to define.
  */
-const hlsQualitySelector = function (options) {
+const hlsQualitySelector = function(options) {
   this.ready(() => {
     onPlayerReady(this, videojs.mergeOptions(defaults, options));
   });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,5 @@
 import videojs from 'video.js';
-import {version as VERSION} from '../package.json';
+import { version as VERSION } from '../package.json';
 import ConcreteButton from './ConcreteButton';
 import ConcreteMenuItem from './ConcreteMenuItem';
 
@@ -61,7 +61,7 @@ class HlsQualitySelectorPlugin {
 
     const placementIndex = player.controlBar.children().length - 2;
     const concreteButtonInstance = player.controlBar.addChild(this._qualityButton,
-      {componentClass: 'qualitySelector'},
+      { componentClass: 'qualitySelector' },
       this.config.placementIndex || placementIndex);
 
     concreteButtonInstance.addClass('vjs-quality-selector');
@@ -113,9 +113,14 @@ class HlsQualitySelectorPlugin {
       if (!levelItems.filter(_existingItem => {
         return _existingItem.item && _existingItem.item.value === levels[i].height;
       }).length) {
+        const itemHeight = levels[i].height;
+        let label = itemHeight + 'p';
+        if (itemHeight === undefined) {
+          label = 'source';
+        }
         const levelItem = this.getQualityMenuItem.call(this, {
-          label: levels[i].height + 'p',
-          value: levels[i].height
+          label: label,
+          value: itemHeight
         });
 
         levelItems.push(levelItem);
@@ -142,7 +147,7 @@ class HlsQualitySelectorPlugin {
     }));
 
     if (this._qualityButton) {
-      this._qualityButton.createItems = function() {
+      this._qualityButton.createItems = function () {
         return levelItems;
       };
       this._qualityButton.update();
@@ -162,7 +167,11 @@ class HlsQualitySelectorPlugin {
     this._currentQuality = height;
 
     if (this.config.displayCurrentQuality) {
-      this.setButtonInnerText(height === 'auto' ? height : `${height}p`);
+      let label = `${height}p`
+      if (height === undefined) {
+        label = 'source';
+      }
+      this.setButtonInnerText(height === 'auto' ? height : label);
     }
 
     for (let i = 0; i < qualityList.length; ++i) {
@@ -215,7 +224,7 @@ const onPlayerReady = (player, options) => {
  * @param    {Object} [options={}]
  *           An object of options left to the plugin author to define.
  */
-const hlsQualitySelector = function(options) {
+const hlsQualitySelector = function (options) {
   this.ready(() => {
     onPlayerReady(this, videojs.mergeOptions(defaults, options));
   });


### PR DESCRIPTION
Unknown resolutions (not specified correctly in M3U8) will now show up as 'source' instead of 'undefined p'.
Might be useful for live HLS/DASH streams that are reencoded.