### PR TITLE
Feature/sort quality levels

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -211,7 +211,7 @@ class HlsQualitySelectorPlugin {
  */
 const onPlayerReady = (player, options) => {
   player.addClass('vjs-hls-quality-selector');
-  player.hlsQualitySelectorCustom = new HlsQualitySelectorPlugin(player, options);
+  player.hlsQualitySelector = new HlsQualitySelectorPlugin(player, options);
 };
 
 /**
@@ -226,16 +226,16 @@ const onPlayerReady = (player, options) => {
  * @param    {Object} [options={}]
  *           An object of options left to the plugin author to define.
  */
-const hlsQualitySelectorCustom = function(options) {
+const hlsQualitySelector = function(options) {
   this.ready(() => {
     onPlayerReady(this, videojs.mergeOptions(defaults, options));
   });
 };
 
 // Register the plugin with video.js.
-registerPlugin('hlsQualitySelectorCustom', hlsQualitySelectorCustom);
+registerPlugin('hlsQualitySelector', hlsQualitySelector);
 
 // Include the version number.
-hlsQualitySelectorCustom.VERSION = VERSION;
+hlsQualitySelector.VERSION = VERSION;
 
-export default hlsQualitySelectorCustom;
+export default hlsQualitySelector;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -47,7 +47,8 @@ class HlsQualitySelectorPlugin {
    * Binds listener for quality level changes.
    */
   bindPlayerEvents() {
-    this.player.qualityLevels().on('addqualitylevel', this.onAddQualityLevel.bind(this));
+    this.player.qualityLevels().on('addqualitylevel', this.onAddQualityLevel.bind(this,
+      this.config.sortAscending));
   }
 
   /**
@@ -101,8 +102,10 @@ class HlsQualitySelectorPlugin {
 
   /**
    * Executed when a quality level is added from HLS playlist.
+   *
+   * @param {boolean} sortAscending - sort quality levels, default is ascending.
    */
-  onAddQualityLevel() {
+  onAddQualityLevel(sortAscending = true) {
 
     const player = this.player;
     const qualityList = player.qualityLevels();
@@ -122,18 +125,21 @@ class HlsQualitySelectorPlugin {
       }
     }
 
-    levelItems.sort((current, next) => {
-      if ((typeof current !== 'object') || (typeof next !== 'object')) {
-        return -1;
-      }
-      if (current.item.value < next.item.value) {
-        return -1;
-      }
-      if (current.item.value > next.item.value) {
-        return 1;
-      }
-      return 0;
-    });
+    if (sortAscending) {
+      levelItems.sort((current, next) => {
+        if ((typeof current !== 'object') || (typeof next !== 'object')) {
+          return -1;
+        }
+        return current.item.value - next.item.value;
+      });
+    } else {
+      levelItems.sort((current, next) => {
+        if ((typeof current !== 'object') || (typeof next !== 'object')) {
+          return -1;
+        }
+        return next.item.value - current.item.value;
+      });
+    }
 
     levelItems.push(this.getQualityMenuItem.call(this, {
       label: player.localize('Auto'),

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,7 +4,10 @@ import ConcreteButton from './ConcreteButton';
 import ConcreteMenuItem from './ConcreteMenuItem';
 
 // Default options for the plugin.
-const defaults = {};
+const defaults = {
+  sortAscending: false,
+  autoPlacement: 'top'
+};
 
 // Cross-compatibility for Video.js 5 and 6.
 const registerPlugin = videojs.registerPlugin || videojs.plugin;
@@ -47,8 +50,7 @@ class HlsQualitySelectorPlugin {
    * Binds listener for quality level changes.
    */
   bindPlayerEvents() {
-    this.player.qualityLevels().on('addqualitylevel', this.onAddQualityLevel.bind(this,
-      this.config.sortAscending, this.config.autoPlacement));
+    this.player.qualityLevels().on('addqualitylevel', this.onAddQualityLevel.bind(this));
   }
 
   /**
@@ -102,17 +104,13 @@ class HlsQualitySelectorPlugin {
 
   /**
    * Executed when a quality level is added from HLS playlist.
-   *
-   * @param {boolean} sortAscending - sort quality levels, default is ascending.
-   * @param {string} autoPlacement - place the 'auto' menu item at the 'top' or
-   * 'bottom' (default).
    */
-  onAddQualityLevel(sortAscending = true, autoPlacement = 'bottom') {
-
+  onAddQualityLevel() {
     const player = this.player;
     const qualityList = player.qualityLevels();
     const levels = qualityList.levels_ || [];
     const levelItems = [];
+    const autoPlacement = this.config.autoPlacement;
     const autoMenuItem = this.getQualityMenuItem.call(this, {
       label: player.localize('Auto'),
       value: 'auto',
@@ -133,7 +131,7 @@ class HlsQualitySelectorPlugin {
     }
 
     // sort the quality level values
-    if (sortAscending) {
+    if (this.config.sortAscending) {
       levelItems.sort((current, next) => {
         if ((typeof current !== 'object') || (typeof next !== 'object')) {
           return -1;


### PR DESCRIPTION
This PR addresses a feature request for ordering the quality levels in descending order ( #38 ). I found a use for this type of feature, so I figured I would throw together a PR. 

* Adds a `sortAscending` config parameter (boolean) that defaults to `true` (how it currently sorts the list)
* Adds a `autoPlacement` config parameter (string) that defaults to placing the 'auto' label at the bottom (how it currently places the item)