### PR TITLE
Dynamic quality selector - Reacts to video.js source changes 

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -26,33 +26,38 @@ class HlsQualitySelectorPlugin {
 
     // Ensure dependencies are met
     if (!this.player.qualityLevels) {
-      console.error(`Error: Missing video.js quality levels plugin (required) - videojs-hls-quality-selector`);
+      console.warn(`Error: Missing videojs-contrib-quality-levels plugin (required by videojs-hls-quality-selector)\nhttps://github.com/videojs/videojs-contrib-quality-levels`);
       return;
     }
 
+    // Begin plugin setup
     this.setupPlugin();
   }
 
+  /**
+   * Setups the plugin, creates DOM elements, adds event listeners
+   */
   setupPlugin() {
-    // Create the quality button.
+    // Create the quality selector button.
     this.createQualityButton();
 
     // Bind event listeners
     this.bindPlayerEvents();
 
-    // Listen for source changes
-    this.player.on('loadedmetadata', () => {
-      this.updatePlugin();
-    });
+    // Listen for video source changes
+    this.player.on('loadedmetadata', () => this.updatePlugin());
   }
 
+  /**
+   * Updates the UI when video.js source changes
+   */
   updatePlugin() {
     // If there is the HLS tech
     if (this.getHls()) {
-      // Show quality selector
+      // Show the quality selector button
       this._qualityButton.show();
     } else {
-      // Hide quality selector
+      // Hide the quality selector
       this._qualityButton.hide();
     }
   }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -41,7 +41,7 @@ class HlsQualitySelectorPlugin {
     this.bindPlayerEvents();
 
     // Listen for source changes
-    this.player.on('loadedmetadata', (e) => {
+    this.player.on('loadedmetadata', () => {
       this.updatePlugin();
     });
   }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,5 @@
 import videojs from 'video.js';
-import {version as VERSION} from './package.json';
+import {version as VERSION} from '../package.json';
 import ConcreteButton from './ConcreteButton';
 import ConcreteMenuItem from './ConcreteMenuItem';
 


### PR DESCRIPTION
I ran into an issue with videojs-hls-quality-selector on my project where I was loading unknown video file types into the player. Some MP4's, some HLS, some MP3's, and only some of them had multiple quality options. 

Currently, this plugin will not work if video.js is initialized with anything but an HLS media. This meant if my player loaded an MP4 file first, and then was given an HLS url, I would have to dispose and recreate the entire video.js instance just to have the quality selector appear. Alternatively I could add the quality levels manually, but why shouldn't this plugin be able to detect and react to changes in player source. Video.js can change tech's on the fly, but this plugin only initializes itself once.

So to improve this, I added 1 new event listener to the plugin that registers when the plugin initializes that listens for when new sources are loaded into video.js. When a new source is loaded, the plugin will then run the check for HLS quality levels. If the tech is HLS, then we will show the quality selector button. However if the tech does not support multiple qualities, such as MP4, then we will hide the quality selector button. Every time the source is changed, we check if the button should be visible or not.

This makes the plugin way more flexible and prevents having to constantly recreate the video.js player just to show or hide the selector. and it does so automatically. 

These changes have been applied to a copy of videojs-hls-quality-selector locally in our repo to solve the issue mentioned above.
https://github.com/lbryio/lbry-desktop/pull/5539

Please let me know if you would like any changes or modifications to better suit general use cases.