### PR TITLE
Check if the level is enabled in the provided Quality Levels

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -118,7 +118,10 @@ class HlsQualitySelectorPlugin {
           value: levels[i].height
         });
 
-        levelItems.push(levelItem);
+        // Check if the level is enabled
+        if (levels[i].enabled) {
+          levelItems.push(levelItem);
+        }
       }
     }
 


### PR DESCRIPTION
Quality levels are still showing even if they are disabled in the QualityLevels object.