### PR TITLE
VIDEOJS: WARN: player.tech().hls is deprecated. Use player.tech().vhs…

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -40,7 +40,7 @@ class HlsQualitySelectorPlugin {
    * @return {*} - videojs-hls-contrib plugin.
    */
   getHls() {
-    return this.player.tech({ IWillNotUseThisInPlugins: true }).hls;
+    return this.player.tech({ IWillNotUseThisInPlugins: true }).vhs;
   }
 
   /**


### PR DESCRIPTION
… instead.