### PR TITLE
Allow usage of setQuality() from external code

### DIFF
--- a/src/ConcreteMenuItem.js
+++ b/src/ConcreteMenuItem.js
@@ -31,15 +31,7 @@ export default class ConcreteMenuItem extends VideoJsMenuItemClass {
      * Click event for menu item.
      */
   handleClick() {
-
-        // Reset other menu items selected status.
-    for (let i = 0; i < this.qualityButton.items.length; ++i) {
-      this.qualityButton.items[i].selected(false);
-    }
-
-        // Set this menu item to selected, and set quality.
+    // Set this menu item to selected, and set quality.
     this.plugin.setQuality(this.item.value);
-    this.selected(true);
-
   }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -169,7 +169,14 @@ class HlsQualitySelectorPlugin {
       const quality = qualityList[i];
 
       quality.enabled = (quality.height === height || height === 'auto');
+    }    
+
+    // Reset other menu items selected status.
+    for (let i = 0; i < this._qualityButton.items.length; ++i) {
+      var menuItem = this._qualityButton.items[i];
+      menuItem.selected(menuItem && menuItem.item && menuItem.item.value === height)
     }
+
     this._qualityButton.unpressButton();
   }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -169,12 +169,15 @@ class HlsQualitySelectorPlugin {
       const quality = qualityList[i];
 
       quality.enabled = (quality.height === height || height === 'auto');
-    }    
+    }
 
     // Reset other menu items selected status.
     for (let i = 0; i < this._qualityButton.items.length; ++i) {
-      var menuItem = this._qualityButton.items[i];
-      menuItem.selected(menuItem && menuItem.item && menuItem.item.value === height)
+      const menuItem = this._qualityButton.items[i];
+
+      if (menuItem) {
+        menuItem.selected(menuItem.item && menuItem.item.value === height);
+      }
     }
 
     this._qualityButton.unpressButton();


### PR DESCRIPTION
Thanks for this plugin!
Currently using the setQuality() method externally almost works, it's just not showing the quality as selected in the list.
This PR just moves that relevant logic from the menuItems clickHandler into the setQuality() method.